### PR TITLE
fix: prevent race condition on connection close

### DIFF
--- a/src/ConnectionManager.cpp
+++ b/src/ConnectionManager.cpp
@@ -177,6 +177,7 @@ namespace eipScanner {
 
 	void ConnectionManager::forwardClose(const SessionInfoIf::SPtr& si, const IOConnection::WPtr& ioConnection) {
 		if (auto ptr = ioConnection.lock()) {
+			ptr->_isOpen = false;  // final removal done on next call to handleConnections()
 			ForwardCloseRequest request;
 
 			request.setConnectionPath(ptr->_connectionPath);
@@ -198,7 +199,6 @@ namespace eipScanner {
 					<< messageRouterResponse.getGeneralStatusCode()
 					<< ". But the connection is removed from ConnectionManager anyway";
 			}
-			ptr->_isOpen = false;  // final clean-up done on next call to handleConnections()
 		} else {
 			Logger(LogLevel::WARNING) << "Attempt to close an already closed connection";
 		}

--- a/src/ConnectionManager.cpp
+++ b/src/ConnectionManager.cpp
@@ -261,7 +261,7 @@ namespace eipScanner {
 						io_ptr = io->second;
 					}
 				}
-				if (io_ptr) {
+				if (io_ptr && io_ptr->_isOpen) {
 					io_ptr->notifyReceiveData(commonPacket.getItems().at(1).getData());
 				} else {
 					Logger(LogLevel::ERROR) << "Received data from unknown connection T2O_ID=" << connectionId;

--- a/src/ConnectionManager.cpp
+++ b/src/ConnectionManager.cpp
@@ -264,7 +264,7 @@ namespace eipScanner {
 				if (io_ptr && io_ptr->_isOpen) {
 					io_ptr->notifyReceiveData(commonPacket.getItems().at(1).getData());
 				} else {
-					Logger(LogLevel::ERROR) << "Received data from unknown connection T2O_ID=" << connectionId;
+					Logger(LogLevel::INFO) << "Received data from unknown connection T2O_ID=" << connectionId;
 				}
 			});
 

--- a/src/ConnectionManager.cpp
+++ b/src/ConnectionManager.cpp
@@ -253,10 +253,16 @@ namespace eipScanner {
 				buffer >> connectionId;
 				Logger(LogLevel::DEBUG) << "Received data from connection T2O_ID=" << connectionId;
 
-				// TODO: std::lock_guard<std::mutex> guard(_connectionMutex);
-				auto io = _connectionMap.find(connectionId);
-				if (io != _connectionMap.end()) {
-					io->second->notifyReceiveData(commonPacket.getItems().at(1).getData());
+				IOConnection::SPtr io_ptr;
+				{
+					std::lock_guard<std::mutex> guard(_connectionMutex);
+					auto io = _connectionMap.find(connectionId);
+					if (io != _connectionMap.end()) {
+						io_ptr = io->second;
+					}
+				}
+				if (io_ptr) {
+					io_ptr->notifyReceiveData(commonPacket.getItems().at(1).getData());
 				} else {
 					Logger(LogLevel::ERROR) << "Received data from unknown connection T2O_ID=" << connectionId;
 				}

--- a/src/ConnectionManager.h
+++ b/src/ConnectionManager.h
@@ -6,6 +6,7 @@
 #define EIPSCANNER_CONNECTIONMANAGER_H
 
 #include <map>
+#include <mutex>
 #include "MessageRouter.h"
 #include "IOConnection.h"
 #include "cip/connectionManager/ConnectionParameters.h"
@@ -76,6 +77,7 @@ namespace eipScanner {
 	private:
 		MessageRouter::SPtr _messageRouter;
 		std::map<cip::CipUint, IOConnection::SPtr> _connectionMap;
+		std::mutex _connectionMutex;
 		std::map<sockets::EndPoint, std::shared_ptr<sockets::UDPBoundSocket>> _socketMap;
 
 		sockets::UDPBoundSocket::SPtr  findOrCreateSocket(const sockets::EndPoint& endPoint);

--- a/src/IOConnection.cpp
+++ b/src/IOConnection.cpp
@@ -100,8 +100,6 @@ namespace eipScanner {
 		auto periodInMicroS = sinceLastHandle.count() * 1000;
 		_connectionTimeoutCount += periodInMicroS;
 		if (!_isOpen) {
-			Logger(LogLevel::WARNING) << "Connection T2O_ID=" << _t2oNetworkConnectionId << " is closed by external party";
-			// _closeHandle();
 			return false;
 		}
 		if (_connectionTimeoutCount > _connectionTimeoutMultiplier * _t2oAPI) {

--- a/src/IOConnection.cpp
+++ b/src/IOConnection.cpp
@@ -101,7 +101,7 @@ namespace eipScanner {
 		_connectionTimeoutCount += periodInMicroS;
 		if (!_isOpen) {
 			Logger(LogLevel::WARNING) << "Connection T2O_ID=" << _t2oNetworkConnectionId << " is closed by external party";
-			_closeHandle();
+			// _closeHandle();
 			return false;
 		}
 		if (_connectionTimeoutCount > _connectionTimeoutMultiplier * _t2oAPI) {

--- a/src/IOConnection.cpp
+++ b/src/IOConnection.cpp
@@ -44,6 +44,7 @@ namespace eipScanner {
 			, _receiveDataHandle([](auto, auto, auto) {})
 			, _closeHandle([]() {})
 			, _sendDataHandle([](auto) {})
+			, _isOpen(false)
 			, _lastHandleTime(std::chrono::steady_clock::now()) {
 	}
 
@@ -98,8 +99,13 @@ namespace eipScanner {
 
 		auto periodInMicroS = sinceLastHandle.count() * 1000;
 		_connectionTimeoutCount += periodInMicroS;
+		if (!_isOpen) {
+			Logger(LogLevel::WARNING) << "Connection T2O_ID=" << _t2oNetworkConnectionId << " is closed by external party";
+			_closeHandle();
+			return false;
+		}
 		if (_connectionTimeoutCount > _connectionTimeoutMultiplier * _t2oAPI) {
-			Logger(LogLevel::WARNING) << "Connection SeriaNumber=" << _serialNumber << " is closed by timeout";
+			Logger(LogLevel::WARNING) << "Connection T2O_ID=" << _t2oNetworkConnectionId << " is closed by timeout";
 			_closeHandle();
 			return false;
 		}

--- a/src/IOConnection.h
+++ b/src/IOConnection.h
@@ -105,6 +105,7 @@ namespace eipScanner {
 		ReceiveDataHandle _receiveDataHandle;
 		CloseHandle _closeHandle;
 		SendDataHandle _sendDataHandle;
+		bool _isOpen;
 
 		std::chrono::steady_clock::time_point _lastHandleTime;
 	};


### PR DESCRIPTION
Prevents races when the user of an ioConnection calls forwardClose in the close callback when connections time out.